### PR TITLE
Add failure reason to both GitSource and GitSourceAnalysis CRDs

### DIFF
--- a/pkg/apis/devconsole/v1alpha1/gitsource_types.go
+++ b/pkg/apis/devconsole/v1alpha1/gitsource_types.go
@@ -52,7 +52,7 @@ type GitSourceStatus struct {
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
 
 	// State represents current state of the GitSource, can be either initializing or ready
-	State State `json:"state"`
+	State State `json:"state,omitempty"`
 
 	// Connection holds information whether the last attempt to reach the git source was successful or not. Optional
 	Connection Connection `json:"connection,omitempty"`
@@ -72,18 +72,34 @@ type Connection struct {
 	// State is the result of the attempt to reach a GitSource. Can be either Failed or OK
 	State ConnectionState `json:"state"`
 
-	// Error has the error message if the attempt to reach a GitSource failed
+	// Error has the error message if the attempt to reach a GitSource failed. Optional
 	Error string `json:"error,omitempty"`
+
+	// Reason represents the reason why the attempt to reach a GitSource failed. Optional
+	Reason ConnectionFailureReason `json:"reason,omitempty"`
 }
 
 // ConnectionState is the result of the attempt to reach a GitSource.
 type ConnectionState string
+// ConnectionFailureReason represents the reason why the attempt to reach a GitSource failed
+type ConnectionFailureReason string
 
-// Failed is the state of Connection when an attempt to reach a GitSource failed
-const Failed ConnectionState = "failed"
+const (
+	// Failed is the state of Connection when an attempt to reach a GitSource failed
+	Failed ConnectionState = "failed"
+	// OK is the state of Connection when an attempt to reach a GitSource was successful
+	OK ConnectionState = "ok"
 
-// OK is the state of Connection when an attempt to reach a GitSource was successful
-const OK ConnectionState = "ok"
+	// RepoNotReachable represents a failure reason when an attempt to reach the git repo failed.
+	// This failure could be caused by either a wrong URL or insufficient permissions needed to access the repo.
+	RepoNotReachable ConnectionFailureReason = "RepoNotReachable"
+	// BranchNotFound represents a failure reason when the specified branch wasn't found in the repository
+	BranchNotFound ConnectionFailureReason = "BranchNotFound"
+	// BadCredentials represents a failure reason when an attempt to authenticate to the repo using the given secret failed
+	BadCredentials ConnectionFailureReason = "BadCredentials"
+	// ConnectionInternalFailure represents a failure reason caused by any internal failure
+	ConnectionInternalFailure ConnectionFailureReason = "InternalFailure"
+)
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/pkg/apis/devconsole/v1alpha1/gitsourceanalysis_types.go
+++ b/pkg/apis/devconsole/v1alpha1/gitsourceanalysis_types.go
@@ -34,7 +34,23 @@ type GitSourceAnalysisStatus struct {
 
 	// Error contains an error message in case the build environment detection fails. Optional
 	Error string `json:"error,omitempty"`
+
+	// Reason represents the reason why the GitSource analysis (build type detection) failed. Optional
+	Reason AnalysisFailureReason `json:"reason,omitempty"`
 }
+
+// AnalysisFailureReason represents the reason why the GitSource analysis (build type detection) failed
+type AnalysisFailureReason string
+
+const (
+	// NotSupportedType represents the failure reason when no appropriate git implementation was found
+	// for the given combination of repository and secret
+	NotSupportedType AnalysisFailureReason = "NotSupportedType"
+	// DetectionFailed represents the failure reason when the actual detection logic failed
+	DetectionFailed AnalysisFailureReason = "DetectionFailed"
+	// AnalysisInternalFailure represents a failure reason caused by any internal failure
+	AnalysisInternalFailure AnalysisFailureReason = "InternalFailure"
+)
 
 // BuildEnvStatistics holds information about detected languages and build types in the GitSource
 type BuildEnvStats struct {


### PR DESCRIPTION
Add short failure reason that can be easily checked by UI (or another client).
for more information on possible failure combinations see this doc: https://docs.google.com/spreadsheets/d/1Qn2cioIXj8r3bcVddzISUZiJ2ODq6hWFg6TI_fIz34U/edit#gid=0